### PR TITLE
Fix name button showing local wallet instead of connected wallet

### DIFF
--- a/packages/client/node/src/api.game.ts
+++ b/packages/client/node/src/api.game.ts
@@ -115,7 +115,7 @@ export const apiGame = async (
         accountId: 0,
         balance: 0,
         lastLogin: Date.now(),
-        name: `${walletAddress.slice(0, 6)}...${walletAddress.slice(-4)}`,
+        name: undefined,
       });
       return;
     }
@@ -130,14 +130,21 @@ export const apiGame = async (
         accountId: 0,
         balance: 0,
         lastLogin: Date.now(),
-        name: `${walletAddress.slice(0, 6)}...${walletAddress.slice(-4)}`,
+        name: undefined,
       });
       return;
     }
 
     let name = profile.username;
-    if (name === walletAddress) {
-      name = `${walletAddress.slice(0, 6)}...${walletAddress.slice(-4)}`;
+    // Detect raw wallet addresses (EVM 0x… or Midnight mn_…) and don't
+    // treat them as a real player name — return undefined so the frontend
+    // can show an appropriate fallback.
+    const looksLikeAddress = name && (
+      /^0x[0-9a-fA-F]{40}$/.test(name) ||
+      name.startsWith("mn_")
+    );
+    if (looksLikeAddress) {
+      name = undefined;
     }
 
     reply.send({
@@ -146,7 +153,7 @@ export const apiGame = async (
       lastLogin: profile.last_login_at
         ? new Date(profile.last_login_at).getTime()
         : Date.now(),
-      name: name || `${walletAddress.slice(0, 6)}...${walletAddress.slice(-4)}`,
+      name: name || undefined,
     });
   });
 };

--- a/packages/frontend/src/effectstream/EffectStreamService.ts
+++ b/packages/frontend/src/effectstream/EffectStreamService.ts
@@ -160,14 +160,13 @@ export class EffectStreamService {
     try {
       const res = await fetch(`${ENV.API_URL}/api/user/${walletAddress}`);
       if (!res.ok) {
-        const fallbackName = truncateAddress(walletAddress);
         return {
           id: "0",
-          username: fallbackName,
+          username: truncateAddress(walletAddress),
           level: 1,
           coins: 0,
           stats: { totalRaces: 0, wins: 0, bestTime: 0 },
-          name: fallbackName,
+          name: undefined,
           balance: 0,
         };
       }
@@ -197,15 +196,13 @@ export class EffectStreamService {
       };
     } catch (e) {
       console.error("[EffectStreamService] getUserProfile error", e);
-      const fallbackName = walletAddress.slice(0, 6) + "..." +
-        walletAddress.slice(-4);
       return {
         id: "0",
-        username: fallbackName,
+        username: truncateAddress(walletAddress),
         level: 1,
         coins: 0,
         stats: { totalRaces: 0, wins: 0, bestTime: 0 },
-        name: fallbackName,
+        name: undefined,
         balance: 0,
       };
     }

--- a/packages/frontend/src/effectstream/EffectStreamWallet.ts
+++ b/packages/frontend/src/effectstream/EffectStreamWallet.ts
@@ -119,6 +119,7 @@ export async function updateSetNameButtonLabel() {
   if (!btnSetName) return;
 
   btnSetName.style.display = 'inline-block';
+  console.log("[updateSetNameButtonLabel] START");
 
   let wallet = getConnectedWallet();
   let local = localWallet;
@@ -131,6 +132,7 @@ export async function updateSetNameButtonLabel() {
   // Determine the effective address (Account Primary Address if available)
   let effectiveAddress: string | null = null;
   const currentAddress = midnightAddress || (wallet && wallet.walletAddress) || (local && local.walletAddress);
+  console.log("[updateSetNameButtonLabel] midnightAddress:", midnightAddress, "wallet:", wallet?.walletAddress, "local:", local?.walletAddress, "currentAddress:", currentAddress);
 
   if (currentAddress) {
     try {
@@ -157,7 +159,11 @@ export async function updateSetNameButtonLabel() {
   let nameFound = false;
   try {
     const profile = await api.getUserProfile(effectiveAddress);
-    if (profile && profile.name) {
+    const nameIsAddress = profile?.name && (
+      /^0x[0-9a-fA-F]{40}$/.test(profile.name) || profile.name.startsWith("mn_")
+    );
+    console.log("[updateSetNameButtonLabel] profile.name:", profile?.name, "nameIsAddress:", nameIsAddress, "effectiveAddress:", effectiveAddress);
+    if (profile && profile.name && !nameIsAddress) {
       btnSetName.textContent = profile.name;
       nameFound = true;
     }
@@ -167,9 +173,12 @@ export async function updateSetNameButtonLabel() {
 
   if (nameFound) return;
 
-  // 2. Use Effective Address (truncated, full on hover)
-  btnSetName.textContent = truncateAddress(effectiveAddress);
-  btnSetName.title = effectiveAddress;
+  // 2. Use connected wallet address (truncated, full on hover)
+  //    Prefer the user-facing wallet (Midnight or EVM) over the internal local wallet
+  const displayAddress = midnightAddress || (wallet && wallet.walletAddress) || effectiveAddress;
+  console.log("[updateSetNameButtonLabel] NO NAME — displayAddress:", displayAddress);
+  btnSetName.textContent = truncateAddress(displayAddress);
+  btnSetName.title = displayAddress;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Backend `/api/user/` was returning raw wallet addresses as the player `name` — now detects EVM (`0x...`) and Midnight (`mn_...`) addresses and returns `undefined` instead
- Frontend `getUserProfile` fallback paths no longer set `name` to a truncated address, allowing the display logic to handle it correctly
- Frontend fallback now shows the connected wallet address (Midnight or EVM) instead of the internal local browser wallet

## Test plan
- [ ] Connect a Midnight wallet and verify the name button shows the truncated Midnight address
- [ ] Verify that if a real player name is set, it still displays correctly
- [ ] Check console logs confirm the correct flow (`[updateSetNameButtonLabel]` entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)