### PR TITLE
Add game_frame mode for embedded use

### DIFF
--- a/packages/frontend/src/main.ts
+++ b/packages/frontend/src/main.ts
@@ -13,6 +13,16 @@ import { soundManager } from "./SoundManager.ts";
 console.log("Block Kart Legends started");
 
 const init = () => {
+    const isGameFrame = new URLSearchParams(window.location.search).get("game_frame") === "true";
+    if (isGameFrame) {
+        for (const id of ["game-header", "sidebar", "bkl-footer"]) {
+            const el = document.getElementById(id);
+            if (el) el.style.display = "none";
+        }
+        document.documentElement.style.overflow = "hidden";
+        document.body.style.overflow = "hidden";
+    }
+
     // Initialize Wallet UI and Local Wallet
     initWalletUI();
     initializeLocalWallet().then(async (wallet) => {


### PR DESCRIPTION
## Summary
- When `?game_frame=true` is set in the URL, hides the header (title bar), sidebar (leaderboard/achievements), footer ("Learn More"), and scrollbars
- Allows the game to be cleanly embedded in an iframe without surrounding chrome

## Test plan
- [ ] Open the game normally — all UI elements visible as before
- [ ] Open with `?game_frame=true` — header, sidebar, footer hidden; no scrollbars
- [ ] Verify game still functions correctly in frame mode (start, setup, race, results)