### PR TITLE
Keep wallet button in game_frame; add hide_connect_wallet flag

### DIFF
--- a/packages/frontend/src/main.ts
+++ b/packages/frontend/src/main.ts
@@ -13,14 +13,14 @@ import { soundManager } from "./SoundManager.ts";
 console.log("Block Kart Legends started");
 
 const init = () => {
-    const isGameFrame = new URLSearchParams(window.location.search).get("game_frame") === "true";
-    if (isGameFrame) {
-        for (const id of ["game-header", "sidebar", "bkl-footer"]) {
-            const el = document.getElementById(id);
-            if (el) el.style.display = "none";
-        }
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("game_frame") === "true") {
+        document.body.classList.add("game-frame");
         document.documentElement.style.overflow = "hidden";
         document.body.style.overflow = "hidden";
+    }
+    if (params.get("hide_connect_wallet") === "true") {
+        document.body.classList.add("hide-connect-wallet");
     }
 
     // Initialize Wallet UI and Local Wallet

--- a/packages/frontend/src/style.css
+++ b/packages/frontend/src/style.css
@@ -894,3 +894,16 @@ td {
   text-align: center;
   max-width: 80%;
 }
+
+body.game-frame #game-header h1,
+body.game-frame #sidebar,
+body.game-frame #bkl-footer,
+body.game-frame #mute-btn {
+  display: none !important;
+}
+
+body.hide-connect-wallet #connect-wallet-btn,
+body.hide-connect-wallet .wallet-btn-wrapper,
+body.hide-connect-wallet #btn-set-name {
+  display: none !important;
+}

--- a/packages/frontend/src/style.css
+++ b/packages/frontend/src/style.css
@@ -902,8 +902,6 @@ body.game-frame #mute-btn {
   display: none !important;
 }
 
-body.hide-connect-wallet #connect-wallet-btn,
-body.hide-connect-wallet .wallet-btn-wrapper,
-body.hide-connect-wallet #btn-set-name {
+body.hide-connect-wallet #game-header {
   display: none !important;
 }

--- a/packages/frontend/src/style.css
+++ b/packages/frontend/src/style.css
@@ -895,10 +895,8 @@ td {
   max-width: 80%;
 }
 
-body.game-frame #game-header h1,
 body.game-frame #sidebar,
-body.game-frame #bkl-footer,
-body.game-frame #mute-btn {
+body.game-frame #bkl-footer {
   display: none !important;
 }
 


### PR DESCRIPTION
## Summary
- In `game_frame=true` mode, the connect wallet button is no longer hidden (only title text, sidebar, footer, and mute button are hidden)
- New `hide_connect_wallet=true` flag explicitly hides the wallet UI (`Connect Wallet` + `SET PLAYER NAME` buttons)
- Switched to body-class + CSS `!important` rules so hides aren't clobbered by `updateSetNameButtonLabel`'s inline `display = 'inline-block'`

## Test plan
- [ ] `?game_frame=true` — header collapses but Connect Wallet remains clickable; sidebar/footer hidden; no scrollbars
- [ ] `?game_frame=true&hide_connect_wallet=true` — same as above but wallet button also hidden
- [ ] `?hide_connect_wallet=true` alone — only wallet button area hidden; rest of UI normal
- [ ] No flags — UI unchanged
- [ ] After connecting wallet, `hide_connect_wallet=true` still hides the `SET PLAYER NAME` button (not overridden by UIManager)